### PR TITLE
Add support for direct collections

### DIFF
--- a/openzwavemqtt/manager.py
+++ b/openzwavemqtt/manager.py
@@ -8,7 +8,7 @@ from .models.instance import OZWInstance
 
 
 class OZWManager(ZWaveBase):
-
+    DIRECT_COLLECTION = "instance"
     EVENT_CHANGED = None
 
     def __init__(self, options: OZWOptions):
@@ -21,9 +21,11 @@ class OZWManager(ZWaveBase):
     def receive_message(self, topic: str, message: dict):
         """Receive an MQTT message."""
         assert topic.startswith(self.options.topic_prefix)
-        topic_parts = deque(
-            ["instance"] + topic[len(self.options.topic_prefix) :].split("/")
-        )
+
+        topic_parts_raw = topic[len(self.options.topic_prefix) :].split("/")
+        if topic_parts_raw[-1] == "":
+            topic_parts_raw.pop()
+        topic_parts = deque(topic_parts_raw)
 
         if message == "":
             payload = EMPTY

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,12 @@ class MockManager(OZWManager):
 
 
 @pytest.fixture
-def mgr():
+def options():
     """Fixture for a manager."""
-    return MockManager()
+    return MockOptions()
+
+
+@pytest.fixture
+def mgr(options):
+    """Fixture for a manager."""
+    return MockManager(options)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1,0 +1,14 @@
+from openzwavemqtt import manager
+
+
+def test_receive_message(mgr):
+    """Test receive message processing."""
+
+    def mock_process_message(topic_parts, payload):
+        """Test data comes in ok."""
+        assert list(topic_parts) == ["1", "node", "2", "value", "3"]
+        assert payload == {"mock": "payload"}
+
+    mgr.process_message = mock_process_message
+
+    mgr.receive_message("/openzwave/1/node/2/value/3/", '{"mock":"payload"}')


### PR DESCRIPTION
Add support for direct collections (I'm open for a better name).

Direct collections are collections that live under an object, but are not named in the topic. Example is the core OZW instance. Messages sent to `<PREFIX>/1` should be sent to the `instance` collection, and so we should interpreted the topic as if it was `<PREFIX>/instance/1`