### PR TITLE
Add values property to OZWNode to return all values of a node

### DIFF
--- a/openzwavemqtt/models/node.py
+++ b/openzwavemqtt/models/node.py
@@ -199,6 +199,17 @@ class OZWNode(ZWaveBase):
         """Return Neighbors."""
         return self.data.get("Neighbors")
 
+    @property
+    def values(self):
+        """Return list of OZWValue child items."""
+        _values = []
+        for instance in self.collections["instance"]:
+            for cc in instance.collections["commandclass"]:
+                for value in cc.collections["value"]:
+                    _values.append(value)
+
+        return _values
+
     def create_collections(self):
         """Create collections that Node supports."""
         return {

--- a/test/models/test_value.py
+++ b/test/models/test_value.py
@@ -23,6 +23,9 @@ def test_value_events(mgr):
     assert events[0].value == "yo"
     assert events[0].parent.id == "4"
 
+    # Test OZWNode.values shortcut
+    assert mgr.get_instance("1").get_node("2").values[0].id == "3"
+
     # Listen for value changed
     mgr.options.listen(EVENT_VALUE_CHANGED, events.append)
     mgr.mock_receive_json(


### PR DESCRIPTION
Adds a shortcut property to OZWNode that returns _all_ OZWValue's belonging to that node, regardless of instance or command class. OZWValue contains command_class and instance information so we can still get to the OZWNodeInstance or OZWNodeCommandClass objects if we need to.