### PR TITLE
Add missing statistics attributes

### DIFF
--- a/openzwavemqtt/models/node.py
+++ b/openzwavemqtt/models/node.py
@@ -53,7 +53,7 @@ class OZWNode(ZWaveBase):
         return self.data.get("isSecurityv1")
 
     @property
-    def is_z_wave_plus(self) -> bool:
+    def is_zwave_plus(self) -> bool:
         """Return isZWavePlus."""
         return self.data.get("isZWavePlus")
 

--- a/openzwavemqtt/models/node_statistics.py
+++ b/openzwavemqtt/models/node_statistics.py
@@ -50,6 +50,21 @@ class OZWNodeStatistics(ZWaveBase):
         return self.data.get("lastRecievedTimeStamp")
 
     @property
+    def last_request_rtt(self):
+        """Return lastRequestRTT."""
+        return self.data.get("lastRequestRTT")
+
+    @property
+    def last_response_rtt(self):
+        """Return lastResponseRTT."""
+        return self.data.get("lastResponseRTT")
+
+    @property
+    def last_sent_time_stamp(self):
+        """Return lastSentTimeStamp."""
+        return self.data.get("lastSentTimeStamp")
+
+    @property
     def last_tx_channel(self):
         """Return lastTXChannel."""
         return self.data.get("lastTXChannel")


### PR DESCRIPTION
Add some missing node statistics attributes to OZWNodeStatistics.

Also renames `OZWNode.is_z_wave_plus` to `is_zwave_plus` so technically a breaking change.