### PR TITLE
Add default __repr__ to models

### DIFF
--- a/openzwavemqtt/base.py
+++ b/openzwavemqtt/base.py
@@ -222,6 +222,11 @@ class ZWaveBase(ABC):
             message,
         )
 
+    def __repr__(self):
+        """Return a representation of this object."""
+        iden = f" {self.id}" if self.id else ""
+        return f"<{type(self).__name__}{iden}>"
+
 
 class DiscardMessages:
     """Class that discards all messages sent to it."""

--- a/openzwavemqtt/models/node_child_base.py
+++ b/openzwavemqtt/models/node_child_base.py
@@ -22,3 +22,14 @@ class OZWNodeChildBase(ZWaveBase):
             return cast(OZWNode, parent)
 
         raise RuntimeError("Object is not a descendant of a Node")
+
+    def __repr__(self):
+        """Return a representation of this object."""
+        iden = f" {self.id}" if self.id else ""
+
+        try:
+            node = self.node.id
+        except RuntimeError:
+            node = "<missing> (bad!)"
+
+        return f"<{type(self).__name__}{iden} (node: {node})>"

--- a/test/models/test_node_child_base.py
+++ b/test/models/test_node_child_base.py
@@ -18,5 +18,11 @@ def test_node():
     grandchild = MockDescendant(None, child, "mock-grandchild-id", 123)
     assert grandchild.node is node
 
+    assert str(grandchild) == "<MockDescendant 123 (node: 1)>"
+
+    no_node_parent = MockDescendant(None, None, "", "")
+
     with pytest.raises(RuntimeError):
-        MockDescendant(None, None, "", "").node
+        no_node_parent.node
+
+    assert str(no_node_parent) == "<MockDescendant (node: <missing> (bad!))>"

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -183,3 +183,13 @@ def test_events(level1, options, caplog):
     event, data = events[0]
     assert event == "super_event"
     assert data == {"event": "test-event-type", "data": {"data": "for-event"}}
+
+
+def test_repr():
+    """Test repr function."""
+
+    class TestNode(base.ZWaveBase):
+        EVENT_CHANGED = "bla"
+
+    inst = TestNode(None, None, "mock-topic-part", "mock-id")
+    assert str(inst) == "<TestNode mock-id>"


### PR DESCRIPTION
Ran into trouble with https://github.com/cgarwood/homeassistant-zwave_mqtt/issues/61 because we can't figure out our objects when we log them. This adds a reasonable default to our base model and base node model. Individual classes can override this if they feel like.