### PR TITLE
Fix get_value helper method

### DIFF
--- a/openzwavemqtt/models/command_class.py
+++ b/openzwavemqtt/models/command_class.py
@@ -54,7 +54,7 @@ class OZWCommandClass(OZWNodeChildBase):
         """Create collections that Node supports."""
         return {"value": ItemCollection(OZWValue)}
 
-    def get_value(self, value_index: ValueIndex) -> Optional[OZWValue]:
+    def get_value_by_index(self, value_index: ValueIndex) -> Optional[OZWValue]:
         """Return a specific OZWValue on this CommandClass (if exists)."""
         # pylint: disable=no-member
         for value in self.values():
@@ -64,4 +64,4 @@ class OZWCommandClass(OZWNodeChildBase):
 
     def has_value(self, value_index: ValueIndex) -> bool:
         """Determine if the CommandClass has the given ValueIndex."""
-        return self.get_value(value_index) is not None
+        return self.get_value_by_index(value_index) is not None

--- a/openzwavemqtt/models/node.py
+++ b/openzwavemqtt/models/node.py
@@ -251,7 +251,7 @@ class OZWNode(ZWaveBase):
     ) -> Optional[OZWValue]:
         """Return a specific OZWValue on this node (if exists)."""
         command_class = self.get_command_class(command_class_id, instance_id)
-        return command_class.get_value(value_index) if command_class else None
+        return command_class.get_value_by_index(value_index) if command_class else None
 
     def has_value(
         self, command_class_id: CommandClass, instance_id: Optional[int] = None


### PR DESCRIPTION
get_value already existed as function, as it was injected by the generic code so renamed the helper to get_value_by_index

fixes #79 