### PR TITLE
Add valueindex for CLEAR_USER_CODE

### DIFF
--- a/openzwavemqtt/const.py
+++ b/openzwavemqtt/const.py
@@ -95,6 +95,7 @@ class ValueIndex(IntEnum):
     BARRIER_OPERATOR_LABEL = 1
     # DoorLock
     DOOR_LOCK_LOCK = 0
+    CLEAR_USER_CODE = 256
     # Meter
     METER_POWER = 2
     METER_RESET = 257


### PR DESCRIPTION
Add valueindex for CLEAR_USER_CODE, to remove user codes from locks.

Fixes #75 

Reference:
```
{
    "Label": "Remove User Code",
    "Value": 0,
    "Units": "",
    "ValueSet": false,
    "ValuePolled": false,
    "ChangeVerified": false,
    "Min": -32768,
    "Max": 32767,
    "Type": "Short",
    "Instance": 1,
    "CommandClass": "COMMAND_CLASS_USER_CODE",
    "Index": 256,
    "Node": 14,
    "Genre": "System",
    "Help": "Remove A UserCode at the Specified Index",
    "ValueIDKey": 72057594287013910,
    "ReadOnly": false,
    "WriteOnly": true,
    "Event": "valueAdded",
    "TimeStamp": 1596659523
}
```