### PR TITLE
Add utility functions for locks

### DIFF
--- a/openzwavemqtt/const.py
+++ b/openzwavemqtt/const.py
@@ -113,6 +113,7 @@ class ValueIndex(IntEnum):
     # DoorLock
     DOOR_LOCK_LOCK = 0
     CLEAR_USER_CODE = 256
+    NUM_USER_CODES = 257
     # Meter
     METER_POWER = 2
     METER_RESET = 257

--- a/openzwavemqtt/const.py
+++ b/openzwavemqtt/const.py
@@ -5,14 +5,17 @@ from enum import Enum, IntEnum
 LOGGER = logging.getLogger("openzwavemqtt")
 
 # Attribute names for utility functions
-ATTR_PARAMETER = "parameter"
-ATTR_POSITION = "position"
-ATTR_VALUE = "value"
+ATTR_CODE_SLOT = "code_slot"
+ATTR_IN_USE = "in_use"
 ATTR_LABEL = "label"
 ATTR_MAX = "max"
 ATTR_MIN = "min"
+ATTR_NAME = "name"
 ATTR_OPTIONS = "options"
+ATTR_PARAMETER = "parameter"
+ATTR_POSITION = "position"
 ATTR_TYPE = "type"
+ATTR_VALUE = "value"
 
 # OZW Events
 EVENT_PLACEHOLDER = "missing"

--- a/openzwavemqtt/exceptions.py
+++ b/openzwavemqtt/exceptions.py
@@ -9,9 +9,13 @@ class NotFoundError(BaseOZWError):
     """Exception that is raised when an entity can't be found."""
 
 
-class WrongTypeError(BaseOZWError):
-    """Exception that gets raised when an input is the wrong type."""
+class NotSupportedError(BaseOZWError):
+    """Exception that is raised when an action isn't supported."""
 
 
-class InvalidValueError(BaseOZWError):
-    """Exception that gets raised when an input value is invalid."""
+class WrongTypeError(NotSupportedError):
+    """Exception that is raised when an input is the wrong type."""
+
+
+class InvalidValueError(NotSupportedError):
+    """Exception that is raised when an input value is invalid."""

--- a/openzwavemqtt/util.py
+++ b/openzwavemqtt/util.py
@@ -1,5 +1,5 @@
 """Utility functions and classes for OpenZWave."""
-from typing import cast, Any, Dict, List, Union
+from typing import cast, Dict, List, Union
 
 from .const import (
     ATTR_CODE_SLOT,
@@ -181,7 +181,9 @@ def set_config_parameter(
     )
 
 
-def get_config_parameters(node: OZWNode) -> List[Dict[str, Any]]:
+def get_config_parameters(
+    node: OZWNode,
+) -> List[Dict[str, Union[int, str, bool, Dict[Union[int, str], int]]]]:
     """Get config parameter from a node."""
     values = []
 

--- a/openzwavemqtt/util.py
+++ b/openzwavemqtt/util.py
@@ -269,7 +269,7 @@ def set_usercode(node: OZWNode, code_slot: int, usercode: str) -> None:
     value.send_value(usercode)  # type: ignore
 
 
-def clear_usercode(node, code_slot):
+def clear_usercode(node: OZWNode, code_slot: int) -> None:
     """Clear usercode in slot X on the lock."""
     value = node.get_value(CommandClass.USER_CODE, ValueIndex.CLEAR_USER_CODE)
 

--- a/openzwavemqtt/util.py
+++ b/openzwavemqtt/util.py
@@ -276,6 +276,6 @@ def clear_usercode(node: OZWNode, code_slot: int) -> None:
     if not value:
         raise WrongTypeError("Entity is not capable of clearing user codes")
 
-    value.send_value(code_slot)
+    value.send_value(code_slot)  # type: ignore
     # Sending twice because the first time it doesn't take
-    value.send_value(code_slot)
+    value.send_value(code_slot)  # type: ignore

--- a/openzwavemqtt/util/__init__.py
+++ b/openzwavemqtt/util/__init__.py
@@ -1,0 +1,1 @@
+"""Utility module for OpenZWave."""

--- a/openzwavemqtt/util/lock.py
+++ b/openzwavemqtt/util/lock.py
@@ -1,0 +1,56 @@
+"""Utility functions for OpenZWave locks."""
+from typing import Dict, List, Union
+
+from ..const import (
+    ATTR_CODE_SLOT,
+    ATTR_IN_USE,
+    ATTR_NAME,
+    CommandClass,
+    ValueGenre,
+    ValueIndex,
+)
+from ..exceptions import InvalidValueError, NotFoundError, WrongTypeError
+from ..models.node import OZWNode
+
+
+def get_code_slots(node: OZWNode) -> List[Dict[str, Union[int, bool, str]]]:
+    """Get all code slots on the lock and whether or not they are used."""
+    command_class = node.get_command_class(CommandClass.USER_CODE)
+
+    if not command_class:
+        raise NotFoundError("Entity doesn't have any user codes available to configure")
+
+    return [
+        {
+            ATTR_CODE_SLOT: value.index.value,
+            ATTR_NAME: value.label,
+            ATTR_IN_USE: value.value_set,
+        }
+        for value in command_class.values()  # type: ignore
+        if value.genre == ValueGenre.USER
+    ]
+
+
+def set_usercode(node: OZWNode, code_slot: int, usercode: str) -> None:
+    """Set the usercode to index X on the lock."""
+    value = node.get_value(CommandClass.USER_CODE, code_slot)
+
+    if not value:
+        raise NotFoundError(f"Code slot {code_slot} not found")
+
+    if len(str(usercode)) < 4:
+        raise InvalidValueError("User code must be at least 4 digits")
+
+    value.send_value(usercode)  # type: ignore
+
+
+def clear_usercode(node: OZWNode, code_slot: int) -> None:
+    """Clear usercode in slot X on the lock."""
+    value = node.get_value(CommandClass.USER_CODE, ValueIndex.CLEAR_USER_CODE)
+
+    if not value:
+        raise WrongTypeError("Entity is not capable of clearing user codes")
+
+    value.send_value(code_slot)  # type: ignore
+    # Sending twice because the first time it doesn't take
+    value.send_value(code_slot)  # type: ignore

--- a/openzwavemqtt/util/lock.py
+++ b/openzwavemqtt/util/lock.py
@@ -9,7 +9,7 @@ from ..const import (
     ValueGenre,
     ValueIndex,
 )
-from ..exceptions import InvalidValueError, NotFoundError, NotSupportedError, WrongTypeError
+from ..exceptions import InvalidValueError, NotFoundError, NotSupportedError
 from ..models.node import OZWNode
 
 

--- a/openzwavemqtt/util/lock.py
+++ b/openzwavemqtt/util/lock.py
@@ -9,7 +9,7 @@ from ..const import (
     ValueGenre,
     ValueIndex,
 )
-from ..exceptions import InvalidValueError, NotFoundError, WrongTypeError
+from ..exceptions import InvalidValueError, NotFoundError, NotSupportedError, WrongTypeError
 from ..models.node import OZWNode
 
 
@@ -18,7 +18,7 @@ def get_code_slots(node: OZWNode) -> List[Dict[str, Union[int, bool, str]]]:
     command_class = node.get_command_class(CommandClass.USER_CODE)
 
     if not command_class:
-        raise WrongTypeError("Node doesn't have code slots")
+        raise NotSupportedError("Node doesn't have code slots")
 
     return [
         {
@@ -49,7 +49,7 @@ def clear_usercode(node: OZWNode, code_slot: int) -> None:
     value = node.get_value(CommandClass.USER_CODE, ValueIndex.CLEAR_USER_CODE)
 
     if not value:
-        raise WrongTypeError("Node is not capable of clearing user codes")
+        raise NotSupportedError("Node is not capable of clearing user codes")
 
     value.send_value(code_slot)  # type: ignore
     # Sending twice because the first time it doesn't take

--- a/openzwavemqtt/util/lock.py
+++ b/openzwavemqtt/util/lock.py
@@ -18,7 +18,7 @@ def get_code_slots(node: OZWNode) -> List[Dict[str, Union[int, bool, str]]]:
     command_class = node.get_command_class(CommandClass.USER_CODE)
 
     if not command_class:
-        raise NotFoundError("Node doesn't have any user codes available to configure")
+        raise WrongTypeError("Node doesn't have code slots")
 
     return [
         {

--- a/openzwavemqtt/util/lock.py
+++ b/openzwavemqtt/util/lock.py
@@ -18,7 +18,7 @@ def get_code_slots(node: OZWNode) -> List[Dict[str, Union[int, bool, str]]]:
     command_class = node.get_command_class(CommandClass.USER_CODE)
 
     if not command_class:
-        raise NotFoundError("Entity doesn't have any user codes available to configure")
+        raise NotFoundError("Node doesn't have any user codes available to configure")
 
     return [
         {
@@ -49,7 +49,7 @@ def clear_usercode(node: OZWNode, code_slot: int) -> None:
     value = node.get_value(CommandClass.USER_CODE, ValueIndex.CLEAR_USER_CODE)
 
     if not value:
-        raise WrongTypeError("Entity is not capable of clearing user codes")
+        raise WrongTypeError("Node is not capable of clearing user codes")
 
     value.send_value(code_slot)  # type: ignore
     # Sending twice because the first time it doesn't take

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -1,13 +1,10 @@
-"""Utility functions and classes for OpenZWave."""
+"""Utility functions for OpenZWave nodes."""
 from typing import cast, Dict, List, Union
 
-from .const import (
-    ATTR_CODE_SLOT,
-    ATTR_IN_USE,
+from ..const import (
     ATTR_LABEL,
     ATTR_MAX,
     ATTR_MIN,
-    ATTR_NAME,
     ATTR_OPTIONS,
     ATTR_PARAMETER,
     ATTR_POSITION,
@@ -15,13 +12,12 @@ from .const import (
     ATTR_VALUE,
     CommandClass,
     ValueGenre,
-    ValueIndex,
     ValueType,
 )
-from .exceptions import InvalidValueError, NotFoundError, WrongTypeError
-from .manager import OZWManager
-from .models.node import OZWNode
-from .models.value import OZWValue
+from ..exceptions import InvalidValueError, NotFoundError, WrongTypeError
+from ..manager import OZWManager
+from ..models.node import OZWNode
+from ..models.value import OZWValue
 
 
 def get_node_from_manager(
@@ -236,46 +232,3 @@ def get_config_parameters(
         values.append(value_to_return)
 
     return values
-
-
-def get_code_slots(node: OZWNode) -> List[Dict[str, Union[int, bool, str]]]:
-    """Get all code slots on the lock and whether or not they are used."""
-    command_class = node.get_command_class(CommandClass.USER_CODE)
-
-    if not command_class:
-        raise NotFoundError("Entity doesn't have any user codes available to configure")
-
-    return [
-        {
-            ATTR_CODE_SLOT: value.index.value,
-            ATTR_NAME: value.label,
-            ATTR_IN_USE: value.value_set,
-        }
-        for value in command_class.values()  # type: ignore
-        if value.genre == ValueGenre.USER
-    ]
-
-
-def set_usercode(node: OZWNode, code_slot: int, usercode: str) -> None:
-    """Set the usercode to index X on the lock."""
-    value = node.get_value(CommandClass.USER_CODE, code_slot)
-
-    if not value:
-        raise NotFoundError(f"Code slot {code_slot} not found")
-
-    if len(str(usercode)) < 4:
-        raise InvalidValueError("User code must be at least 4 digits")
-
-    value.send_value(usercode)  # type: ignore
-
-
-def clear_usercode(node: OZWNode, code_slot: int) -> None:
-    """Clear usercode in slot X on the lock."""
-    value = node.get_value(CommandClass.USER_CODE, ValueIndex.CLEAR_USER_CODE)
-
-    if not value:
-        raise WrongTypeError("Entity is not capable of clearing user codes")
-
-    value.send_value(code_slot)  # type: ignore
-    # Sending twice because the first time it doesn't take
-    value.send_value(code_slot)  # type: ignore


### PR DESCRIPTION
- Add utility functions for locks:
  - get code slots
  - set code
  - clear code

This is a follow on to #92 (I will rebase once that's merged). As discussed with @cgarwood I will also be adding Home Assistant WS API commands for these functions once home-assistant/core#40527 has been merged.