### PR TITLE
Fix bitset and switch bitset config input value

### DIFF
--- a/openzwavemqtt/models/value.py
+++ b/openzwavemqtt/models/value.py
@@ -36,12 +36,12 @@ class OZWValue(OZWNodeChildBase):
         return self.data.get("Units")
 
     @property
-    def min(self) -> int:
+    def min(self) -> Optional[int]:
         """Return Min."""
         return self.data.get("Min")
 
     @property
-    def max(self) -> int:
+    def max(self) -> Optional[int]:
         """Return Max."""
         return self.data.get("Max")
 

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -104,7 +104,7 @@ def _set_bitset_config_parameter(
             (
                 "Configuration parameter value must be in the form of a "
                 f"list of dicts with the {ATTR_VALUE} key and either the "
-                f"{ATTR_POSITION} or {ATTR_LABEL} keys defined. {ATTR_VALUE} "
+                f"{ATTR_POSITION} or {ATTR_LABEL} key defined. {ATTR_VALUE} "
                 f"should be a bool, {ATTR_POSITION} should be an int, and "
                 f"{ATTR_LABEL} should be a string."
             )

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -76,6 +76,8 @@ def _set_list_config_parameter(value: OZWValue, new_value: Union[int, str]) -> i
             value.send_value(payload)  # type: ignore
             return payload
 
+        raise NotFoundError(f"New value is not a valid option ({value.value['List']})")  # type: ignore
+
     raise WrongTypeError(
         (
             f"Configuration parameter type {value.type} does not match "

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -129,7 +129,9 @@ def _set_bitset_config_parameter(
         is None
         for new_bit in new_value
     ):
-        raise NotFoundError("Configuration parameter value has an invalid key")
+        raise NotFoundError(
+            "Configuration parameter value has an invalid bit position or label"
+        )
 
     value.send_value(new_value)  # type: ignore
     return new_value

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -92,15 +92,13 @@ def _set_bitset_config_parameter(
     # ATTR_POSITION is an int and ATTR_LABEL is a str. Check that ATTR_VALUE is
     # provided and is bool.
     if not isinstance(new_value, list) or any(
-        [
-            (ATTR_POSITION in bit and ATTR_LABEL in bit)
-            or (ATTR_POSITION not in bit and ATTR_LABEL not in bit)
-            or (ATTR_POSITION in bit and not isinstance(bit[ATTR_POSITION], int))
-            or (ATTR_LABEL in bit and not isinstance(bit[ATTR_LABEL], str))
-            or ATTR_VALUE not in bit
-            or not isinstance(bit[ATTR_VALUE], bool)
-            for bit in new_value
-        ]
+        (ATTR_POSITION in bit and ATTR_LABEL in bit)
+        or (ATTR_POSITION not in bit and ATTR_LABEL not in bit)
+        or (ATTR_POSITION in bit and not isinstance(bit[ATTR_POSITION], int))
+        or (ATTR_LABEL in bit and not isinstance(bit[ATTR_LABEL], str))
+        or ATTR_VALUE not in bit
+        or not isinstance(bit[ATTR_VALUE], bool)
+        for bit in new_value
     ):
         raise WrongTypeError(
             (
@@ -115,11 +113,11 @@ def _set_bitset_config_parameter(
     # Check that all keys in dictionary are a valid position or label
     if any(
         next(
-            [
+            (
                 (ATTR_POSITION in new_bit and new_bit[ATTR_POSITION] == int(bit["Position"]))  # type: ignore
                 or (ATTR_LABEL in new_bit and new_bit[ATTR_LABEL] == int(bit["Label"]))  # type: ignore
                 for bit in value.value  # type: ignore
-            ],
+            ),
             None,
         )
         is None

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -170,7 +170,7 @@ def set_config_parameter(
 
 def get_config_parameters(
     node: OZWNode,
-) -> List[Dict[str, Union[int, str, bool, Dict[Union[int, str], bool]]]]:
+) -> List[Dict[str, Union[int, str, bool, List[Dict[[str, Union[int, str, bool]]]]]]]:
     """Get config parameter from a node."""
     values = []
 
@@ -210,7 +210,7 @@ def get_config_parameters(
                 {
                     ATTR_LABEL: bit["Label"],  # type: ignore
                     ATTR_POSITION: int(bit["Position"]),  # type: ignore
-                    ATTR_VALUE: int(bit["Value"]),  # type: ignore
+                    ATTR_VALUE: bool(bit["Value"]),  # type: ignore
                 }
                 for bit in value.value  # type: ignore
             ]

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -88,6 +88,8 @@ def _set_bitset_config_parameter(
     value: OZWValue, new_value: List[Dict[str, Union[int, str, bool]]]
 ) -> List[Dict[str, Union[int, str, bool]]]:
     """Set a ValueType.BITSET config parameter."""
+    # Check that ATTR_VALUE is provided and is bool, check that exactly one of ATTR_POSITION
+    # and ATTR_LABEL is provided, and that ATTR_POSITION is an int and ATTR_LABEL is a str
     if not isinstance(new_value, list) or any(
         [
             ATTR_VALUE not in bit

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -88,15 +88,16 @@ def _set_bitset_config_parameter(
     value: OZWValue, new_value: List[Dict[str, Union[int, str, bool]]]
 ) -> List[Dict[str, Union[int, str, bool]]]:
     """Set a ValueType.BITSET config parameter."""
-    # Check that ATTR_VALUE is provided and is bool, check that exactly one of ATTR_POSITION
-    # and ATTR_LABEL is provided, and that ATTR_POSITION is an int and ATTR_LABEL is a str
+    # Check that exactly one of ATTR_POSITION and ATTR_LABEL is provided, and that
+    # ATTR_POSITION is an int and ATTR_LABEL is a str. Check that ATTR_VALUE is
+    # provided and is bool.
     if not isinstance(new_value, list) or any(
         [
-            ATTR_VALUE not in bit
-            or (ATTR_POSITION in bit and ATTR_LABEL in bit)
+            (ATTR_POSITION in bit and ATTR_LABEL in bit)
             or (ATTR_POSITION not in bit and ATTR_LABEL not in bit)
             or (ATTR_POSITION in bit and not isinstance(bit[ATTR_POSITION], int))
             or (ATTR_LABEL in bit and not isinstance(bit[ATTR_LABEL], str))
+            or ATTR_VALUE not in bit
             or not isinstance(bit[ATTR_VALUE], bool)
             for bit in new_value
         ]

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -85,26 +85,17 @@ def _set_list_config_parameter(value: OZWValue, new_value: Union[int, str]) -> i
 
 
 def _set_bitset_config_parameter(
-    value: OZWValue, new_value: Dict[Union[int, str], int]
-) -> Dict[Union[int, str], int]:
+    value: OZWValue, new_value: Dict[Union[int, str], bool]
+) -> Dict[Union[int, str], bool]:
     """Set a ValueType.BITSET config parameter."""
-    try:
-        if isinstance(new_value, dict) and any(
-            [int(val) not in (0, 1) for val in new_value.values()]
-        ):
-            raise WrongTypeError(
-                (
-                    "Configuration parameter value must be in the form of a "
-                    "dict with keys being the label or position of a "
-                    "particular bit and values being 0 or 1"
-                )
-            )
-    except ValueError:
+    if not isinstance(new_value, dict) or any(
+        [not isinstance(val, bool) for val in new_value.values()]
+    ):
         raise WrongTypeError(
             (
                 "Configuration parameter value must be in the form of a "
                 "dict with keys being the label or position of a "
-                "particular bit and values being 0 or 1"
+                "particular bit and values being a boolean"
             )
         )
 
@@ -146,8 +137,8 @@ def _set_int_config_parameter(parameter: int, value: OZWValue, new_value: int) -
 def set_config_parameter(
     node: OZWNode,
     parameter: int,
-    new_value: Union[int, str, bool, Dict[Union[int, str], int]],
-) -> Union[int, str, bool, Dict[Union[int, str], int]]:
+    new_value: Union[int, str, bool, Dict[Union[int, str], bool]],
+) -> Union[int, str, bool, Dict[Union[int, str], bool]]:
     """Set config parameter to a node."""
     value = node.get_value(CommandClass.CONFIGURATION, parameter)
     if not value:
@@ -179,7 +170,7 @@ def set_config_parameter(
 
 def get_config_parameters(
     node: OZWNode,
-) -> List[Dict[str, Union[int, str, bool, Dict[Union[int, str], int]]]]:
+) -> List[Dict[str, Union[int, str, bool, Dict[Union[int, str], bool]]]]:
     """Get config parameter from a node."""
     values = []
 

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -114,8 +114,14 @@ def _set_bitset_config_parameter(
     if any(
         next(
             (
-                (ATTR_POSITION in new_bit and new_bit[ATTR_POSITION] == int(bit["Position"]))  # type: ignore
-                or (ATTR_LABEL in new_bit and new_bit[ATTR_LABEL] == int(bit["Label"]))  # type: ignore
+                (
+                    ATTR_POSITION in new_bit
+                    and new_bit[ATTR_POSITION] == int(bit["Position"])  # type: ignore
+                )
+                or (
+                    ATTR_LABEL in new_bit
+                    and new_bit[ATTR_LABEL] == int(bit["Label"])  # type: ignore
+                )
                 for bit in value.value  # type: ignore
             ),
             None,

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -76,7 +76,9 @@ def _set_list_config_parameter(value: OZWValue, new_value: Union[int, str]) -> i
             value.send_value(payload)  # type: ignore
             return payload
 
-        raise NotFoundError(f"New value is not a valid option ({value.value['List']})")  # type: ignore
+        raise NotFoundError(
+            f"New value is not a valid option ({value.value['List']})"  # type: ignore
+        )
 
     raise WrongTypeError(
         (

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -91,6 +91,7 @@ def _set_bitset_config_parameter(
     if not isinstance(new_value, list) or any(
         [
             ATTR_VALUE not in bit
+            or (ATTR_POSITION in bit and ATTR_LABEL in bit)
             or (ATTR_POSITION not in bit and ATTR_LABEL not in bit)
             or (ATTR_POSITION in bit and not isinstance(bit[ATTR_POSITION], int))
             or (ATTR_LABEL in bit and not isinstance(bit[ATTR_LABEL], str))

--- a/test/util/__init__.py
+++ b/test/util/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for util module."""

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,0 +1,129 @@
+"""Tests for node util submodule."""
+from openzwavemqtt.const import ATTR_LABEL, ATTR_POSITION, ATTR_VALUE, ValueType
+from openzwavemqtt.exceptions import InvalidValueError, NotFoundError, WrongTypeError
+from openzwavemqtt.models.value import OZWValue
+import pytest
+
+from openzwavemqtt.util.node import (
+    _set_bitset_config_parameter,
+    _set_bool_config_parameter,
+    _set_int_config_parameter,
+    _set_list_config_parameter,
+)
+
+
+class MockValue(OZWValue):
+    """Mock OZWValue."""
+
+    def __init__(self, type: ValueType, value=None, min=None, max=None):
+        self._type = type
+        self._value = value
+        self._min = min
+        self._max = max
+
+    @property
+    def value(self):
+        """Mock OZWValue.value."""
+        return self._value
+
+    @property
+    def type(self):
+        """Mock OZWValue.value."""
+        return self._type
+
+    @property
+    def min(self):
+        """Mock OZWValue.min."""
+        return self._min
+
+    @property
+    def max(self):
+        """Mock OZWValue.max."""
+        return self._max
+
+    def send_value(self, new_value):
+        """Mock OZWValue.send_value()."""
+        pass
+
+
+def test_set_bool_config_parameter():
+    """Test setting a ValueType.BOOL config parameter."""
+    mock_value = MockValue(ValueType.BOOL)
+
+    _set_bool_config_parameter(mock_value, True)
+    _set_bool_config_parameter(mock_value, False)
+    _set_bool_config_parameter(mock_value, "True")
+    _set_bool_config_parameter(mock_value, "False")
+
+    with pytest.raises(WrongTypeError):
+        _set_bool_config_parameter(mock_value, "test")
+
+    with pytest.raises(WrongTypeError):
+        _set_bool_config_parameter(mock_value, 95)
+
+
+def test_set_list_config_parameter():
+    """Test setting a ValueType.LIST config parameter."""
+    mock_value = MockValue(ValueType.LIST, {"List": [{"Label": "test", "Value": 0}]})
+
+    _set_list_config_parameter(mock_value, "0")
+    _set_list_config_parameter(mock_value, 0)
+    _set_list_config_parameter(mock_value, "test")
+
+    with pytest.raises(WrongTypeError):
+        _set_list_config_parameter(mock_value, ["test"])
+
+
+def test_set_bitset_config_parameter():
+    """Test setting a ValueType.BITSET config parameter."""
+    mock_value = MockValue(
+        ValueType.BITSET, [{"Position": 1, "Label": "test", "Value": False}]
+    )
+    with pytest.raises(WrongTypeError):
+        _set_bitset_config_parameter(
+            mock_value, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]
+        )
+
+    with pytest.raises(WrongTypeError):
+        _set_bitset_config_parameter(mock_value, [{ATTR_VALUE: True}])
+
+    with pytest.raises(WrongTypeError):
+        _set_bitset_config_parameter(
+            mock_value, [{ATTR_POSITION: "test", ATTR_VALUE: True}]
+        )
+
+    with pytest.raises(WrongTypeError):
+        _set_bitset_config_parameter(mock_value, [{ATTR_LABEL: 1, ATTR_VALUE: True}])
+
+    with pytest.raises(WrongTypeError):
+        _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 1}])
+
+    with pytest.raises(WrongTypeError):
+        _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 1, ATTR_VALUE: 1}])
+
+    with pytest.raises(NotFoundError):
+        _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 2, ATTR_VALUE: True}])
+
+    with pytest.raises(NotFoundError):
+        _set_bitset_config_parameter(
+            mock_value, [{ATTR_LABEL: "test not found", ATTR_VALUE: True}]
+        )
+
+    _set_bitset_config_parameter(mock_value, [{ATTR_LABEL: "test", ATTR_VALUE: True}])
+    _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 1, ATTR_VALUE: True}])
+
+
+def test_set_int_config_parameter():
+    """Test setting a ValueType.INT config parameter."""
+    mock_value = MockValue(ValueType.INT, value=1, min=0, max=10)
+
+    with pytest.raises(WrongTypeError):
+        _set_int_config_parameter(mock_value, "test")
+
+    with pytest.raises(InvalidValueError):
+        _set_int_config_parameter(mock_value, -1)
+
+    with pytest.raises(InvalidValueError):
+        _set_int_config_parameter(mock_value, 11)
+
+    _set_int_config_parameter(mock_value, 1)

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -49,6 +49,7 @@ def test_set_list_config_parameter(node, mock_value, mock_get_value):
     """Test setting a ValueType.LIST config parameter."""
     mock_value.type = ValueType.LIST
     mock_value.value = {"List": [{"Label": "test", "Value": 0}]}
+
     assert set_config_parameter(node, 1, "0") == 0
     assert set_config_parameter(node, 1, 0) == 0
     assert set_config_parameter(node, 1, "test") == 0

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,94 +1,101 @@
 """Tests for node util submodule."""
-from unittest.mock import Mock
+from openzwavemqtt.models.node import OZWNode
+from unittest.mock import Mock, patch
 
 import pytest
 
 from openzwavemqtt.const import ATTR_LABEL, ATTR_POSITION, ATTR_VALUE, ValueType
 from openzwavemqtt.exceptions import InvalidValueError, NotFoundError, WrongTypeError
 from openzwavemqtt.models.value import OZWValue
-from openzwavemqtt.util.node import (
-    _set_bitset_config_parameter,
-    _set_bool_config_parameter,
-    _set_int_config_parameter,
-    _set_list_config_parameter,
-)
+from openzwavemqtt.util.node import set_config_parameter
 
 
-def test_set_bool_config_parameter():
+def test_set_bool_config_parameter(options):
     """Test setting a ValueType.BOOL config parameter."""
     mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.BOOL
 
-    _set_bool_config_parameter(mock_value, True)
-    _set_bool_config_parameter(mock_value, False)
-    _set_bool_config_parameter(mock_value, "True")
-    _set_bool_config_parameter(mock_value, "False")
+    node = OZWNode(options, None, "test", None)
 
-    with pytest.raises(WrongTypeError):
-        _set_bool_config_parameter(mock_value, "test")
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
+        assert set_config_parameter(node, 1, True)
+        assert not set_config_parameter(node, 1, False)
+        assert set_config_parameter(node, 1, "True")
+        assert not set_config_parameter(node, 1, "False")
 
-    with pytest.raises(WrongTypeError):
-        _set_bool_config_parameter(mock_value, 95)
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, "test")
+
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, 95)
 
 
-def test_set_list_config_parameter():
+def test_set_list_config_parameter(options):
     """Test setting a ValueType.LIST config parameter."""
     mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.LIST
     mock_value.value = {"List": [{"Label": "test", "Value": 0}]}
 
-    _set_list_config_parameter(mock_value, "0")
-    _set_list_config_parameter(mock_value, 0)
-    _set_list_config_parameter(mock_value, "test")
+    node = OZWNode(options, None, "test", None)
 
-    with pytest.raises(NotFoundError):
-        _set_list_config_parameter(mock_value, 1)
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
+        assert set_config_parameter(node, 1, "0") == 0
+        assert set_config_parameter(node, 1, 0) == 0
+        assert set_config_parameter(node, 1, "test") == 0
 
-    with pytest.raises(WrongTypeError):
-        _set_list_config_parameter(mock_value, ["test"])
+        with pytest.raises(NotFoundError):
+            set_config_parameter(node, 1, 1)
+
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, ["test"])
 
 
-def test_set_bitset_config_parameter():
+def test_set_bitset_config_parameter(options):
     """Test setting a ValueType.BITSET config parameter."""
     mock_value = Mock(spec=OZWValue)
-    mock_value.type = ValueType.BOOL
+    mock_value.type = ValueType.BITSET
     mock_value.value = [{"Position": 1, "Label": "test", "Value": False}]
 
-    with pytest.raises(WrongTypeError):
-        _set_bitset_config_parameter(
-            mock_value, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]
-        )
+    node = OZWNode(options, None, "test", None)
 
-    with pytest.raises(WrongTypeError):
-        _set_bitset_config_parameter(mock_value, [{ATTR_VALUE: True}])
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(
+                node, 1, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]
+            )
 
-    with pytest.raises(WrongTypeError):
-        _set_bitset_config_parameter(
-            mock_value, [{ATTR_POSITION: "test", ATTR_VALUE: True}]
-        )
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, [{ATTR_VALUE: True}])
 
-    with pytest.raises(WrongTypeError):
-        _set_bitset_config_parameter(mock_value, [{ATTR_LABEL: 1, ATTR_VALUE: True}])
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, [{ATTR_POSITION: "test", ATTR_VALUE: True}])
 
-    with pytest.raises(WrongTypeError):
-        _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 1}])
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, [{ATTR_LABEL: 1, ATTR_VALUE: True}])
 
-    with pytest.raises(WrongTypeError):
-        _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 1, ATTR_VALUE: 1}])
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, [{ATTR_POSITION: 1}])
 
-    with pytest.raises(NotFoundError):
-        _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 2, ATTR_VALUE: True}])
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, [{ATTR_POSITION: 1, ATTR_VALUE: 1}])
 
-    with pytest.raises(NotFoundError):
-        _set_bitset_config_parameter(
-            mock_value, [{ATTR_LABEL: "test not found", ATTR_VALUE: True}]
-        )
+        with pytest.raises(NotFoundError):
+            set_config_parameter(node, 1, [{ATTR_POSITION: 2, ATTR_VALUE: True}])
 
-    _set_bitset_config_parameter(mock_value, [{ATTR_LABEL: "test", ATTR_VALUE: True}])
-    _set_bitset_config_parameter(mock_value, [{ATTR_POSITION: 1, ATTR_VALUE: True}])
+        with pytest.raises(NotFoundError):
+            set_config_parameter(
+                node, 1, [{ATTR_LABEL: "test not found", ATTR_VALUE: True}]
+            )
+
+        assert set_config_parameter(
+            node, 1, [{ATTR_LABEL: "test", ATTR_VALUE: True}]
+        ) == [{ATTR_LABEL: "test", ATTR_VALUE: True}]
+        assert set_config_parameter(
+            node, 1, [{ATTR_POSITION: 1, ATTR_VALUE: True}]
+        ) == [{ATTR_POSITION: 1, ATTR_VALUE: True}]
 
 
-def test_set_int_config_parameter():
+def test_set_int_config_parameter(options):
     """Test setting a ValueType.INT config parameter."""
     mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.INT
@@ -96,13 +103,17 @@ def test_set_int_config_parameter():
     mock_value.min = 0
     mock_value.max = 10
 
-    with pytest.raises(WrongTypeError):
-        _set_int_config_parameter(mock_value, "test")
+    node = OZWNode(options, None, "test", None)
 
-    with pytest.raises(InvalidValueError):
-        _set_int_config_parameter(mock_value, -1)
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, "test")
 
-    with pytest.raises(InvalidValueError):
-        _set_int_config_parameter(mock_value, 11)
+        with pytest.raises(InvalidValueError):
+            set_config_parameter(node, 1, -1)
 
-    _set_int_config_parameter(mock_value, 1)
+        with pytest.raises(InvalidValueError):
+            set_config_parameter(node, 1, 11)
+
+        assert set_config_parameter(node, 1, 1) == 1
+        assert set_config_parameter(node, 1, "1") == 1

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -29,7 +29,7 @@ def mock_get_value_fixture(mock_value):
         yield
 
 
-def test_set_bool_config_parameter(node, mock_value, mock_get_value):
+def test_set_bool_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
     """Test setting a ValueType.BOOL config parameter."""
     mock_value.type = ValueType.BOOL
 
@@ -45,7 +45,7 @@ def test_set_bool_config_parameter(node, mock_value, mock_get_value):
         set_config_parameter(node, 1, 95)
 
 
-def test_set_list_config_parameter(node, mock_value, mock_get_value):
+def test_set_list_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
     """Test setting a ValueType.LIST config parameter."""
     mock_value.type = ValueType.LIST
     mock_value.value = {"List": [{"Label": "test", "Value": 0}]}
@@ -64,7 +64,7 @@ def test_set_list_config_parameter(node, mock_value, mock_get_value):
     assert set_config_parameter(node, 1, "test") == "test"
 
 
-def test_set_bitset_config_parameter(node, mock_value, mock_get_value):
+def test_set_bitset_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
     """Test setting a ValueType.BITSET config parameter."""
     mock_value.type = ValueType.BITSET
     mock_value.value = [{"Position": 1, "Label": "test", "Value": False}]
@@ -105,7 +105,7 @@ def test_set_bitset_config_parameter(node, mock_value, mock_get_value):
     ]
 
 
-def test_set_int_config_parameter(node, mock_value, mock_get_value):
+def test_set_int_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
     """Test setting a ValueType.INT config parameter."""
     mock_value.type = ValueType.INT
     mock_value.value = 1
@@ -125,7 +125,7 @@ def test_set_int_config_parameter(node, mock_value, mock_get_value):
     assert set_config_parameter(node, 1, "1") == 1
 
 
-def test_invalid_config_parameter_types(node, mock_value, mock_get_value):
+def test_invalid_config_parameter_types(node, mock_value, mock_get_value):  # pylint: disable=W0613
     """Test invalid config parameter types."""
     for value_type in (
         ValueType.DECIMAL,

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -117,3 +117,31 @@ def test_set_int_config_parameter(options):
 
         assert set_config_parameter(node, 1, 1) == 1
         assert set_config_parameter(node, 1, "1") == 1
+
+
+def test_invalid_config_parameter_types(options):
+    """Test invalid config parameter types."""
+    mock_value = Mock(spec=OZWValue)
+
+    node = OZWNode(options, None, "test", None)
+
+    for value_type in (
+        ValueType.DECIMAL,
+        ValueType.RAW,
+        ValueType.SCHEDULE,
+        ValueType.UNKNOWN,
+    ):
+        mock_value.type = value_type
+        with patch(
+            "openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value
+        ):
+            with pytest.raises(WrongTypeError):
+                set_config_parameter(node, 1, True)
+
+
+def test_config_parameter_not_found(options):
+    """Test config parameter can't be found."""
+    node = OZWNode(options, None, "test", None)
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=None):
+        with pytest.raises(NotFoundError):
+            set_config_parameter(node, 1, True)

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -49,6 +49,10 @@ def test_set_list_config_parameter(options):
         with pytest.raises(WrongTypeError):
             set_config_parameter(node, 1, ["test"])
 
+    mock_value.value = {"List": [{"Label": "test", "Value": "test"}]}
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
+        assert set_config_parameter(node, 1, "test") == "test"
+
 
 def test_set_bitset_config_parameter(options):
     """Test setting a ValueType.BITSET config parameter."""

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -29,7 +29,9 @@ def mock_get_value_fixture(mock_value):
         yield
 
 
-def test_set_bool_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
+def test_set_bool_config_parameter(
+    node, mock_value, mock_get_value  # pylint: disable=unused-argument
+):
     """Test setting a ValueType.BOOL config parameter."""
     mock_value.type = ValueType.BOOL
 
@@ -45,7 +47,9 @@ def test_set_bool_config_parameter(node, mock_value, mock_get_value):  # pylint:
         set_config_parameter(node, 1, 95)
 
 
-def test_set_list_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
+def test_set_list_config_parameter(
+    node, mock_value, mock_get_value  # pylint: disable=unused-argument
+):
     """Test setting a ValueType.LIST config parameter."""
     mock_value.type = ValueType.LIST
     mock_value.value = {"List": [{"Label": "test", "Value": 0}]}
@@ -64,7 +68,9 @@ def test_set_list_config_parameter(node, mock_value, mock_get_value):  # pylint:
     assert set_config_parameter(node, 1, "test") == "test"
 
 
-def test_set_bitset_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
+def test_set_bitset_config_parameter(
+    node, mock_value, mock_get_value  # pylint: disable=unused-argument
+):
     """Test setting a ValueType.BITSET config parameter."""
     mock_value.type = ValueType.BITSET
     mock_value.value = [{"Position": 1, "Label": "test", "Value": False}]
@@ -105,7 +111,9 @@ def test_set_bitset_config_parameter(node, mock_value, mock_get_value):  # pylin
     ]
 
 
-def test_set_int_config_parameter(node, mock_value, mock_get_value):  # pylint: disable=W0613
+def test_set_int_config_parameter(
+    node, mock_value, mock_get_value  # pylint: disable=unused-argument
+):
     """Test setting a ValueType.INT config parameter."""
     mock_value.type = ValueType.INT
     mock_value.value = 1
@@ -125,7 +133,9 @@ def test_set_int_config_parameter(node, mock_value, mock_get_value):  # pylint: 
     assert set_config_parameter(node, 1, "1") == 1
 
 
-def test_invalid_config_parameter_types(node, mock_value, mock_get_value):  # pylint: disable=W0613
+def test_invalid_config_parameter_types(
+    node, mock_value, mock_get_value,  # pylint: disable=unused-argument
+):
     """Test invalid config parameter types."""
     for value_type in (
         ValueType.DECIMAL,

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,5 +1,6 @@
 """Tests for node util submodule."""
 import pytest
+from unittest.mock import Mock
 
 from openzwavemqtt.const import ATTR_LABEL, ATTR_POSITION, ATTR_VALUE, ValueType
 from openzwavemqtt.exceptions import InvalidValueError, NotFoundError, WrongTypeError
@@ -12,43 +13,10 @@ from openzwavemqtt.util.node import (
 )
 
 
-class MockValue(OZWValue):
-    """Mock OZWValue."""
-
-    def __init__(self, type: ValueType, value=None, min=None, max=None):
-        self._type = type
-        self._value = value
-        self._min = min
-        self._max = max
-
-    @property
-    def value(self):
-        """Mock OZWValue.value."""
-        return self._value
-
-    @property
-    def type(self):
-        """Mock OZWValue.value."""
-        return self._type
-
-    @property
-    def min(self):
-        """Mock OZWValue.min."""
-        return self._min
-
-    @property
-    def max(self):
-        """Mock OZWValue.max."""
-        return self._max
-
-    def send_value(self, new_value):
-        """Mock OZWValue.send_value()."""
-        pass
-
-
 def test_set_bool_config_parameter():
     """Test setting a ValueType.BOOL config parameter."""
-    mock_value = MockValue(ValueType.BOOL)
+    mock_value = Mock(spec=OZWValue)
+    mock_value.type = ValueType.BOOL
 
     _set_bool_config_parameter(mock_value, True)
     _set_bool_config_parameter(mock_value, False)
@@ -64,7 +32,9 @@ def test_set_bool_config_parameter():
 
 def test_set_list_config_parameter():
     """Test setting a ValueType.LIST config parameter."""
-    mock_value = MockValue(ValueType.LIST, {"List": [{"Label": "test", "Value": 0}]})
+    mock_value = Mock(spec=OZWValue)
+    mock_value.type = ValueType.LIST
+    mock_value.value = {"List": [{"Label": "test", "Value": 0}]}
 
     _set_list_config_parameter(mock_value, "0")
     _set_list_config_parameter(mock_value, 0)
@@ -79,9 +49,10 @@ def test_set_list_config_parameter():
 
 def test_set_bitset_config_parameter():
     """Test setting a ValueType.BITSET config parameter."""
-    mock_value = MockValue(
-        ValueType.BITSET, [{"Position": 1, "Label": "test", "Value": False}]
-    )
+    mock_value = Mock(spec=OZWValue)
+    mock_value.type = ValueType.BOOL
+    mock_value.value = [{"Position": 1, "Label": "test", "Value": False}]
+    
     with pytest.raises(WrongTypeError):
         _set_bitset_config_parameter(
             mock_value, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]
@@ -118,7 +89,11 @@ def test_set_bitset_config_parameter():
 
 def test_set_int_config_parameter():
     """Test setting a ValueType.INT config parameter."""
-    mock_value = MockValue(ValueType.INT, value=1, min=0, max=10)
+    mock_value = Mock(spec=OZWValue)
+    mock_value.type = ValueType.INT
+    mock_value.value = 1
+    mock_value.min = 0
+    mock_value.max = 10
 
     with pytest.raises(WrongTypeError):
         _set_int_config_parameter(mock_value, "test")

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,9 +1,9 @@
 """Tests for node util submodule."""
+import pytest
+
 from openzwavemqtt.const import ATTR_LABEL, ATTR_POSITION, ATTR_VALUE, ValueType
 from openzwavemqtt.exceptions import InvalidValueError, NotFoundError, WrongTypeError
 from openzwavemqtt.models.value import OZWValue
-import pytest
-
 from openzwavemqtt.util.node import (
     _set_bitset_config_parameter,
     _set_bool_config_parameter,

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -52,7 +52,7 @@ def test_set_bitset_config_parameter():
     mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.BOOL
     mock_value.value = [{"Position": 1, "Label": "test", "Value": False}]
-    
+
     with pytest.raises(WrongTypeError):
         _set_bitset_config_parameter(
             mock_value, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -70,6 +70,9 @@ def test_set_list_config_parameter():
     _set_list_config_parameter(mock_value, 0)
     _set_list_config_parameter(mock_value, "test")
 
+    with pytest.raises(NotFoundError):
+        _set_list_config_parameter(mock_value, 1)
+
     with pytest.raises(WrongTypeError):
         _set_list_config_parameter(mock_value, ["test"])
 

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,11 +1,11 @@
 """Tests for node util submodule."""
-from openzwavemqtt.models.node import OZWNode
 from unittest.mock import Mock, patch
 
 import pytest
 
 from openzwavemqtt.const import ATTR_LABEL, ATTR_POSITION, ATTR_VALUE, ValueType
 from openzwavemqtt.exceptions import InvalidValueError, NotFoundError, WrongTypeError
+from openzwavemqtt.models.node import OZWNode
 from openzwavemqtt.models.value import OZWValue
 from openzwavemqtt.util.node import set_config_parameter
 

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,6 +1,7 @@
 """Tests for node util submodule."""
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 from openzwavemqtt.const import ATTR_LABEL, ATTR_POSITION, ATTR_VALUE, ValueType
 from openzwavemqtt.exceptions import InvalidValueError, NotFoundError, WrongTypeError

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -10,125 +10,122 @@ from openzwavemqtt.models.value import OZWValue
 from openzwavemqtt.util.node import set_config_parameter
 
 
-def test_set_bool_config_parameter(options):
+@pytest.fixture(name="node")
+def mock_node_fixture(options):
+    """Mock OZWNode."""
+    return OZWNode(options, None, "test", None)
+
+
+@pytest.fixture(name="mock_value")
+def mock_value_fixture():
+    """Mock OZWValue."""
+    return Mock(spec=OZWValue)
+
+
+@pytest.fixture(name="mock_get_value")
+def mock_get_value_fixture(mock_value):
+    """Patch get_value."""
+    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
+        yield
+
+
+def test_set_bool_config_parameter(node, mock_value, mock_get_value):
     """Test setting a ValueType.BOOL config parameter."""
-    mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.BOOL
 
-    node = OZWNode(options, None, "test", None)
+    assert set_config_parameter(node, 1, True)
+    assert not set_config_parameter(node, 1, False)
+    assert set_config_parameter(node, 1, "True")
+    assert not set_config_parameter(node, 1, "False")
 
-    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
-        assert set_config_parameter(node, 1, True)
-        assert not set_config_parameter(node, 1, False)
-        assert set_config_parameter(node, 1, "True")
-        assert not set_config_parameter(node, 1, "False")
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, "test")
 
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, "test")
-
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, 95)
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, 95)
 
 
-def test_set_list_config_parameter(options):
+def test_set_list_config_parameter(node, mock_value, mock_get_value):
     """Test setting a ValueType.LIST config parameter."""
-    mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.LIST
     mock_value.value = {"List": [{"Label": "test", "Value": 0}]}
+    assert set_config_parameter(node, 1, "0") == 0
+    assert set_config_parameter(node, 1, 0) == 0
+    assert set_config_parameter(node, 1, "test") == 0
 
-    node = OZWNode(options, None, "test", None)
+    with pytest.raises(NotFoundError):
+        set_config_parameter(node, 1, 1)
 
-    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
-        assert set_config_parameter(node, 1, "0") == 0
-        assert set_config_parameter(node, 1, 0) == 0
-        assert set_config_parameter(node, 1, "test") == 0
-
-        with pytest.raises(NotFoundError):
-            set_config_parameter(node, 1, 1)
-
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, ["test"])
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, ["test"])
 
     mock_value.value = {"List": [{"Label": "test", "Value": "test"}]}
-    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
-        assert set_config_parameter(node, 1, "test") == "test"
+    assert set_config_parameter(node, 1, "test") == "test"
 
 
-def test_set_bitset_config_parameter(options):
+def test_set_bitset_config_parameter(node, mock_value, mock_get_value):
     """Test setting a ValueType.BITSET config parameter."""
-    mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.BITSET
     mock_value.value = [{"Position": 1, "Label": "test", "Value": False}]
 
-    node = OZWNode(options, None, "test", None)
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(
+            node, 1, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]
+        )
 
-    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(
-                node, 1, [{ATTR_POSITION: 1, ATTR_LABEL: "test", ATTR_VALUE: True}]
-            )
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, [{ATTR_VALUE: True}])
 
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, [{ATTR_VALUE: True}])
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, [{ATTR_POSITION: "test", ATTR_VALUE: True}])
 
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, [{ATTR_POSITION: "test", ATTR_VALUE: True}])
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, [{ATTR_LABEL: 1, ATTR_VALUE: True}])
 
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, [{ATTR_LABEL: 1, ATTR_VALUE: True}])
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, [{ATTR_POSITION: 1}])
 
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, [{ATTR_POSITION: 1}])
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, [{ATTR_POSITION: 1, ATTR_VALUE: 1}])
 
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, [{ATTR_POSITION: 1, ATTR_VALUE: 1}])
+    with pytest.raises(NotFoundError):
+        set_config_parameter(node, 1, [{ATTR_POSITION: 2, ATTR_VALUE: True}])
 
-        with pytest.raises(NotFoundError):
-            set_config_parameter(node, 1, [{ATTR_POSITION: 2, ATTR_VALUE: True}])
+    with pytest.raises(NotFoundError):
+        set_config_parameter(
+            node, 1, [{ATTR_LABEL: "test not found", ATTR_VALUE: True}]
+        )
 
-        with pytest.raises(NotFoundError):
-            set_config_parameter(
-                node, 1, [{ATTR_LABEL: "test not found", ATTR_VALUE: True}]
-            )
-
-        assert set_config_parameter(
-            node, 1, [{ATTR_LABEL: "test", ATTR_VALUE: True}]
-        ) == [{ATTR_LABEL: "test", ATTR_VALUE: True}]
-        assert set_config_parameter(
-            node, 1, [{ATTR_POSITION: 1, ATTR_VALUE: True}]
-        ) == [{ATTR_POSITION: 1, ATTR_VALUE: True}]
+    assert set_config_parameter(node, 1, [{ATTR_LABEL: "test", ATTR_VALUE: True}]) == [
+        {ATTR_LABEL: "test", ATTR_VALUE: True}
+    ]
+    assert set_config_parameter(node, 1, [{ATTR_POSITION: 1, ATTR_VALUE: True}]) == [
+        {ATTR_POSITION: 1, ATTR_VALUE: True}
+    ]
 
 
-def test_set_int_config_parameter(options):
+def test_set_int_config_parameter(node, mock_value, mock_get_value):
     """Test setting a ValueType.INT config parameter."""
-    mock_value = Mock(spec=OZWValue)
     mock_value.type = ValueType.INT
     mock_value.value = 1
     mock_value.min = 0
     mock_value.max = 10
 
-    node = OZWNode(options, None, "test", None)
+    with pytest.raises(WrongTypeError):
+        set_config_parameter(node, 1, "test")
 
-    with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value):
-        with pytest.raises(WrongTypeError):
-            set_config_parameter(node, 1, "test")
+    with pytest.raises(InvalidValueError):
+        set_config_parameter(node, 1, -1)
 
-        with pytest.raises(InvalidValueError):
-            set_config_parameter(node, 1, -1)
+    with pytest.raises(InvalidValueError):
+        set_config_parameter(node, 1, 11)
 
-        with pytest.raises(InvalidValueError):
-            set_config_parameter(node, 1, 11)
-
-        assert set_config_parameter(node, 1, 1) == 1
-        assert set_config_parameter(node, 1, "1") == 1
+    assert set_config_parameter(node, 1, 1) == 1
+    assert set_config_parameter(node, 1, "1") == 1
 
 
-def test_invalid_config_parameter_types(options):
+def test_invalid_config_parameter_types(node, mock_value, mock_get_value):
     """Test invalid config parameter types."""
-    mock_value = Mock(spec=OZWValue)
-
-    node = OZWNode(options, None, "test", None)
-
     for value_type in (
         ValueType.DECIMAL,
         ValueType.RAW,
@@ -136,16 +133,12 @@ def test_invalid_config_parameter_types(options):
         ValueType.UNKNOWN,
     ):
         mock_value.type = value_type
-        with patch(
-            "openzwavemqtt.util.node.OZWNode.get_value", return_value=mock_value
-        ):
-            with pytest.raises(WrongTypeError):
-                set_config_parameter(node, 1, True)
+        with pytest.raises(WrongTypeError):
+            set_config_parameter(node, 1, True)
 
 
-def test_config_parameter_not_found(options):
+def test_config_parameter_not_found(node):
     """Test config parameter can't be found."""
-    node = OZWNode(options, None, "test", None)
     with patch("openzwavemqtt.util.node.OZWNode.get_value", return_value=None):
         with pytest.raises(NotFoundError):
             set_config_parameter(node, 1, True)


### PR DESCRIPTION
Per the [docs](https://github.com/OpenZWave/qt-openzwave/blob/master/docs/MQTT.md#setvalue) the value of a bit is supposed to be `true` or `false`. I also updated the structure of the input value (list of dicts instead of dict of bits) because I wasn't setting the new value correctly and this requires less transformation during this step.