### PR TITLE
Include help text in get_config_parameters

### DIFF
--- a/openzwavemqtt/const.py
+++ b/openzwavemqtt/const.py
@@ -16,6 +16,7 @@ ATTR_PARAMETER = "parameter"
 ATTR_POSITION = "position"
 ATTR_TYPE = "type"
 ATTR_VALUE = "value"
+ATTR_HELP = "help"
 
 # OZW Events
 EVENT_PLACEHOLDER = "missing"

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -10,6 +10,7 @@ from ..const import (
     ATTR_POSITION,
     ATTR_TYPE,
     ATTR_VALUE,
+    ATTR_HELP,
     CommandClass,
     ValueGenre,
     ValueType,
@@ -221,6 +222,7 @@ def get_config_parameters(
             ATTR_LABEL: value.label,
             ATTR_TYPE: value.type.value,
             ATTR_PARAMETER: value.index.value,
+            ATTR_HELP: value.help,
         }
 
         if value.type == ValueType.BOOL:


### PR DESCRIPTION
Includes help text in `get_config_parameters` so we can include the help text in the HA frontend