### PR TITLE
Return the integer value of OZWValue.index instead of ValueIndex enum

### DIFF
--- a/openzwavemqtt/models/value.py
+++ b/openzwavemqtt/models/value.py
@@ -65,7 +65,7 @@ class OZWValue(OZWNodeChildBase):
     @property
     def index(self) -> int:
         """Return Index."""
-        return self.data.get("Index")
+        return self.data["Index"]
 
     @property
     def genre(self) -> ValueGenre:

--- a/openzwavemqtt/models/value.py
+++ b/openzwavemqtt/models/value.py
@@ -64,16 +64,9 @@ class OZWValue(OZWNodeChildBase):
         return self.parent.command_class_id
 
     @property
-    def index(self) -> Union[ValueIndex, int]:
+    def index(self) -> int:
         """Return Index."""
-        try:
-            # TODO: we can make this prettier by returning the
-            # ValueIndex belonging to this specific CC
-            # Now it will return the first value matching this int value
-            # Nothing breaks but it isn't very pretty
-            return ValueIndex(self.data.get("Index"))
-        except ValueError:
-            return int(self.data.get("Index"))
+        return self.data.get("Index")
 
     @property
     def genre(self) -> ValueGenre:

--- a/openzwavemqtt/models/value.py
+++ b/openzwavemqtt/models/value.py
@@ -64,7 +64,7 @@ class OZWValue(OZWNodeChildBase):
         return self.parent.command_class_id
 
     @property
-    def index(self) -> ValueIndex:
+    def index(self) -> Union[ValueIndex, int]:
         """Return Index."""
         try:
             # TODO: we can make this prettier by returning the
@@ -73,7 +73,7 @@ class OZWValue(OZWNodeChildBase):
             # Nothing breaks but it isn't very pretty
             return ValueIndex(self.data.get("Index"))
         except ValueError:
-            return ValueIndex.UNKNOWN
+            return int(self.data.get("Index"))
 
     @property
     def genre(self) -> ValueGenre:

--- a/openzwavemqtt/models/value.py
+++ b/openzwavemqtt/models/value.py
@@ -8,7 +8,6 @@ from ..const import (
     CommandClass,
     ValueGenre,
     ValueType,
-    ValueIndex,
 )
 from .node_child_base import OZWNodeChildBase
 

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -14,7 +14,6 @@ from ..const import (
     CommandClass,
     ValueGenre,
     ValueType,
-    ValueIndex,
 )
 from ..exceptions import InvalidValueError, NotFoundError, WrongTypeError
 from ..manager import OZWManager

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -219,15 +219,10 @@ def get_config_parameters(
         ):
             continue
 
-        if isinstance(value.index, ValueIndex):
-            parameter = value.index.value
-        else:
-            parameter = value.index
-
         value_to_return = {
             ATTR_LABEL: value.label,
             ATTR_TYPE: value.type.value,
-            ATTR_PARAMETER: parameter,
+            ATTR_PARAMETER: value.index,
             ATTR_HELP: value.help,
         }
 

--- a/openzwavemqtt/util/node.py
+++ b/openzwavemqtt/util/node.py
@@ -14,6 +14,7 @@ from ..const import (
     CommandClass,
     ValueGenre,
     ValueType,
+    ValueIndex,
 )
 from ..exceptions import InvalidValueError, NotFoundError, WrongTypeError
 from ..manager import OZWManager
@@ -218,10 +219,15 @@ def get_config_parameters(
         ):
             continue
 
+        if isinstance(value.index, ValueIndex):
+            parameter = value.index.value
+        else:
+            parameter = value.index
+
         value_to_return = {
             ATTR_LABEL: value.label,
             ATTR_TYPE: value.type.value,
-            ATTR_PARAMETER: value.index.value,
+            ATTR_PARAMETER: parameter,
             ATTR_HELP: value.help,
         }
 


### PR DESCRIPTION
Return the integer value of OZWValue.index instead of the ValueIndex enum. There's a number of issues with COMMAND_CLASS_CONFIGURATION and COMMAND_CLASS_USERCODE where valid indexes would return ValueIndex.UNKNOWN with an integer value of 999. This fixes that issue until we're able to set up ValueIndex enums for each command class.