### PR TITLE
Add instance id message filter

### DIFF
--- a/openzwavemqtt/manager.py
+++ b/openzwavemqtt/manager.py
@@ -37,6 +37,11 @@ class OZWManager(ZWaveBase):
         assert topic.startswith(self.options.topic_prefix)
 
         topic_parts_raw = topic[len(self.options.topic_prefix) :].split("/")
+        instance_id = self.options.instance_id
+
+        if instance_id is not None and topic_parts_raw[0] != instance_id:
+            return
+
         if topic_parts_raw[-1] == "":
             topic_parts_raw.pop()
         topic_parts = deque(topic_parts_raw)

--- a/openzwavemqtt/manager.py
+++ b/openzwavemqtt/manager.py
@@ -39,7 +39,7 @@ class OZWManager(ZWaveBase):
         topic_parts_raw = topic[len(self.options.topic_prefix) :].split("/")
         instance_id = self.options.instance_id
 
-        if instance_id is not None and topic_parts_raw[0] != instance_id:
+        if instance_id is not None and topic_parts_raw[0] != str(instance_id):
             return
 
         if topic_parts_raw[-1] == "":

--- a/openzwavemqtt/options.py
+++ b/openzwavemqtt/options.py
@@ -12,7 +12,7 @@ class OZWOptions:
         self,
         send_message: Callable[[str, Union[str, dict]], None],
         topic_prefix: str = "OpenZWave/",
-        instance_id: Optional[str] = None,
+        instance_id: Optional[int] = None,
     ):
         """Initialize class."""
         self.send_message = send_message

--- a/openzwavemqtt/options.py
+++ b/openzwavemqtt/options.py
@@ -1,5 +1,5 @@
 """Options for the OZW MQTT Connection."""
-from typing import TYPE_CHECKING, Callable, Dict, List, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from .base import ZWaveBase  # noqa: F401
@@ -12,11 +12,13 @@ class OZWOptions:
         self,
         send_message: Callable[[str, Union[str, dict]], None],
         topic_prefix: str = "OpenZWave/",
+        instance_id: Optional[str] = None,
     ):
         """Initialize class."""
         self.send_message = send_message
         self.topic_prefix = topic_prefix
         self.listeners: Dict[str, List[Callable[[Union[dict, "ZWaveBase"]], None]]] = {}
+        self.instance_id = instance_id
 
         # Make sure topic prefix ends in a slash
         assert topic_prefix[-1] == "/"

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -20,7 +20,7 @@ def test_receive_message(mgr):
     assert messages == 1
 
     # Assert that we can filter messages with incorrect instance id.
-    mgr.options.instance_id = "1"
+    mgr.options.instance_id = 1
     mgr.receive_message("OpenZWave/2/node/2/value/3/", '{"mock":"payload"}')
 
     assert messages == 1

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -4,11 +4,27 @@
 def test_receive_message(mgr):
     """Test receive message processing."""
 
+    messages = 0
+
     def mock_process_message(topic_parts, payload):
         """Test data comes in ok."""
+        nonlocal messages
+        messages += 1
         assert list(topic_parts) == ["1", "node", "2", "value", "3"]
         assert payload == {"mock": "payload"}
 
     mgr.process_message = mock_process_message
 
     mgr.receive_message("OpenZWave/1/node/2/value/3/", '{"mock":"payload"}')
+
+    assert messages == 1
+
+    # Assert that we can filter messages with incorrect instance id.
+    mgr.options.instance_id = "1"
+    mgr.receive_message("OpenZWave/2/node/2/value/3/", '{"mock":"payload"}')
+
+    assert messages == 1
+
+    mgr.receive_message("OpenZWave/1/node/2/value/3/", '{"mock":"payload"}')
+
+    assert messages == 2


### PR DESCRIPTION
- This optional filter allows easy filtering of messages for a specific instance id at the root level.