### PR TITLE
Add MQTT client util

### DIFF
--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -125,7 +125,7 @@ class MQTTClient:
         to_publish = (topic, json.dumps(payload))
         self.publish_queue.put_nowait(to_publish)
 
-    async def handle_publish(self) -> None:
+    async def _handle_publish(self) -> None:
         """Publish messages as they are put on the queue."""
         while True:
             to_publish: tuple = await self.publish_queue.get()
@@ -162,7 +162,7 @@ class MQTTClient:
             # Reset the reconnect interval after successful connection.
             self.reconnect_interval = 1
 
-            publish_task = asyncio.create_task(self.handle_publish())
+            publish_task = asyncio.create_task(self._handle_publish())
             tasks.add(publish_task)
 
             # Messages that doesn't match a filter will get logged and handled here.

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -36,6 +36,7 @@ class MQTTClient:
             client_options["client_id"] = mqtt.base62(uuid.uuid4().int, padding=22)
         if "logger" not in client_options:
             client_options["logger"] = PAHO_MQTT_LOGGER
+        client_options["clean_session"] = True
         self.client_options = client_options
         self.asyncio_client: AsyncioClient = None
         self.create_client()
@@ -178,17 +179,8 @@ class MQTTClient:
             topic = f"{manager.options.topic_prefix}#"
             await self.subscribe(topic)
 
-            # Unsubscribe the manager when exiting the context manager
-            # but before closing the client.
-            stack.push_async_callback(self._unsubscribe_manager, manager)
-
             # Wait for everything to complete (or fail due to, e.g., network errors).
             await asyncio.gather(*tasks)
-
-    async def _unsubscribe_manager(self, manager: OZWManager) -> None:
-        """Unsubscribe a manager."""
-        topic = f"{manager.options.topic_prefix}#"
-        await self.unsubscribe(topic)
 
 
 async def handle_messages(messages: Any, callback: Callable[[str, str], None]) -> None:

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -138,7 +138,7 @@ class MQTTClient:
         # Reconnect automatically until the client is stopped.
         while True:
             try:
-                await self.subscribe_manager(manager)
+                await self._subscribe_manager(manager)
             except MqttError as err:
                 self.reconnect_interval = min(self.reconnect_interval * 2, 900)
                 LOGGER.error(
@@ -149,7 +149,7 @@ class MQTTClient:
                 await asyncio.sleep(self.reconnect_interval)
                 self.create_client()  # reset connect/reconnect futures
 
-    async def subscribe_manager(self, manager: OZWManager) -> None:
+    async def _subscribe_manager(self, manager: OZWManager) -> None:
         """Connect and subscribe to manager topics."""
         async with AsyncExitStack() as stack:
             # Keep track of the asyncio tasks that we create, so that

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -1,0 +1,229 @@
+"""Provide an MQTT client for connecting to the ozwdaemon via MQTT broker."""
+import asyncio
+import json
+import logging
+from contextlib import AsyncExitStack
+from typing import Any, Callable, Optional, Set, Union
+
+from asyncio_mqtt import Client as AsyncioClient, MqttError
+from paho.mqtt.properties import Properties
+from paho.mqtt.subscribeoptions import SubscribeOptions
+
+from openzwavemqtt import OZWManager, OZWOptions
+from openzwavemqtt.const import LOGGER
+
+TOPIC_OPENZWAVE = "OpenZWave"
+
+
+class MQTTClient:
+    """Represent an MQTT client."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 1883,
+        **client_options: Any,
+    ) -> None:
+        """Set up client."""
+        self.manager: Optional[OZWManager] = None
+        self.host = host
+        self.port = port
+        self.client_options = client_options
+        self.asyncio_client: AsyncioClient = None
+        self.create_client()
+        self.reconnect_interval = 1
+        self.tasks: Set[asyncio.Task] = set()
+
+    def create_client(self) -> None:
+        """Create the asyncio client."""
+        self.asyncio_client = AsyncioClient(
+            self.host,
+            self.port,
+            **self.client_options,
+        )
+
+    async def connect(self, *, timeout: float = 10.0) -> None:
+        """Connect to the broker.
+
+        Can raise asyncio_mqtt.MqttError.
+        """
+        await self.asyncio_client.connect(timeout=timeout)
+
+    async def disconnect(self, *, timeout: float = 10.0) -> None:
+        """Disconnect from the broker.
+
+        Can raise asyncio_mqtt.MqttError.
+        """
+        await self.asyncio_client.disconnect(timeout=timeout)
+
+    async def publish(  # pylint:disable=too-many-arguments
+        self,
+        topic: str,
+        payload: Optional[str] = None,
+        qos: int = 0,
+        retain: bool = False,
+        properties: Optional[Properties] = None,
+        timeout: float = 10,
+    ) -> None:
+        """Publish to topic.
+
+        Can raise asyncio_mqtt.MqttError.
+        """
+        params: dict = {"qos": qos, "retain": retain, "timeout": timeout}
+        if payload:
+            params["payload"] = payload
+        if properties:
+            params["properties"] = properties
+
+        LOGGER.debug("Sending message topic: %s, payload: %s", topic, payload)
+        await self.asyncio_client.publish(topic, **params)
+
+    async def subscribe(  # pylint:disable=too-many-arguments
+        self,
+        topic: str,
+        qos: int = 0,
+        options: Optional[SubscribeOptions] = None,
+        properties: Optional[Properties] = None,
+        timeout: float = 10.0,
+    ) -> None:
+        """Subscribe to topic.
+
+        Can raise asyncio_mqtt.MqttError.
+        """
+        params: dict = {"qos": qos, "timeout": timeout}
+        if options:
+            params["options"] = options
+        if properties:
+            params["properties"] = properties
+
+        await self.asyncio_client.subscribe(topic, **params)
+
+    async def unsubscribe(
+        self, topic: str, properties: Optional[Properties] = None, timeout: float = 10.0
+    ) -> None:
+        """Unsubscribe from topic.
+
+        Can raise asyncio_mqtt.MqttError.
+        """
+        params: dict = {"timeout": timeout}
+        if properties:
+            params["properties"] = properties
+
+        await self.asyncio_client.unsubscribe(topic, **params)
+
+    async def safe_publish(self, *args: Any, **kwargs: Any) -> None:
+        """Publish messages and catch MqttError."""
+        try:
+            await self.publish(*args, **kwargs)
+        except MqttError as err:
+            LOGGER.error("Failed sending message: %s", err)
+
+    def add_manager(self, manager: OZWManager) -> None:
+        """Add an OZW manager."""
+        self.manager = manager
+
+    def send_message(self, topic: str, payload: Union[str, dict]) -> None:
+        """Send a message from the manager options."""
+        task = asyncio.create_task(self.safe_publish(topic, json.dumps(payload)))
+        self.tasks.add(task)
+
+    async def start_client(self) -> None:
+        """Start the client."""
+        # Reconnect automatically until the client is stopped.
+        while True:
+            try:
+                await self.connect_subscribe()
+            except MqttError as err:
+                self.reconnect_interval = min(self.reconnect_interval * 2, 900)
+                LOGGER.error(
+                    "MQTT error: %s. Reconnecting in %s seconds",
+                    err,
+                    self.reconnect_interval,
+                )
+                await asyncio.sleep(self.reconnect_interval)
+                self.create_client()  # reset connect/reconnect futures
+
+    async def connect_subscribe(self) -> None:
+        """Connect and subscribe to topic."""
+        async with AsyncExitStack() as stack:
+            # Keep track of the asyncio tasks that we create, so that
+            # we can cancel them on exit.
+            tasks = self.tasks = set()
+            stack.push_async_callback(cancel_tasks, tasks)
+
+            # Connect to the MQTT broker.
+            await stack.enter_async_context(self.asyncio_client)
+            # Reset the reconnect interval after successful connection.
+            self.reconnect_interval = 1
+
+            # Messages that doesn't match a filter will get logged and handled here.
+            messages = await stack.enter_async_context(
+                self.asyncio_client.unfiltered_messages()
+            )
+            assert self.manager is not None
+            task = asyncio.create_task(
+                handle_messages(messages, self.manager.receive_message)
+            )
+            tasks.add(task)
+
+            # Note that we subscribe *after* starting the message loggers.
+            # Otherwise, we may miss retained messages.
+            topic = f"{self.manager.options.topic_prefix}#"
+            await self.subscribe(topic)
+
+            # Wait for everything to complete (or fail due to, e.g., network errors).
+            # Make sure we await new tasks added while awaiting the first tasks.
+            while self.tasks:
+                current_tasks = list(self.tasks)
+                self.tasks.clear()
+                await asyncio.gather(*current_tasks)
+
+
+async def handle_messages(messages: Any, callback: Callable[[str, str], None]) -> None:
+    """Handle messages with callback."""
+    async for message in messages:
+        # Note that we assume that the message payload is an
+        # UTF8-encoded string (hence the `bytes.decode` call).
+        payload = message.payload.decode()
+        LOGGER.debug("Received message topic: %s, payload: %s", message.topic, payload)
+        callback(message.topic, payload)
+
+
+async def cancel_tasks(tasks: Set[asyncio.Task]) -> None:
+    """Cancel tasks."""
+    for task in tasks:
+        if task.done():
+            continue
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+async def run_client() -> None:
+    """Run client."""
+    client = MQTTClient("localhost")
+    options = OZWOptions(
+        send_message=client.send_message, topic_prefix=f"{TOPIC_OPENZWAVE}/"
+    )
+    manager = OZWManager(options)
+    client.add_manager(manager)
+
+    await client.start_client()
+
+
+def main() -> None:
+    """Run main."""
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    logging.basicConfig(format=fmt, level=logging.DEBUG)
+    LOGGER.info("Starting client.")
+
+    try:
+        asyncio.run(run_client())
+    except KeyboardInterrupt:
+        LOGGER.info("Exiting client.")
+
+
+if __name__ == "__main__":
+    main()

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -2,10 +2,12 @@
 import asyncio
 import json
 import logging
+import uuid
 from contextlib import AsyncExitStack
 from typing import Any, Callable, Dict, Optional, Set, Union
 
 from asyncio_mqtt import Client as AsyncioClient, MqttError
+import paho.mqtt.client as mqtt
 from paho.mqtt.properties import Properties
 from paho.mqtt.subscribeoptions import SubscribeOptions
 
@@ -30,6 +32,8 @@ class MQTTClient:
         self.managers: Dict[int, OZWManager] = {}
         self.host = host
         self.port = port
+        if "client_id" not in client_options:
+            client_options["client_id"] = mqtt.base62(uuid.uuid4().int, padding=22)
         self.client_options = client_options
         self.asyncio_client: AsyncioClient = None
         self.create_client()

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -154,7 +154,6 @@ class MQTTClient:
             # Keep track of the asyncio tasks that we create, so that
             # we can cancel them on exit.
             tasks: Set[asyncio.Task] = set()
-            stack.push_async_callback(cancel_tasks, tasks)
 
             # Connect to the MQTT broker.
             await stack.enter_async_context(self.asyncio_client)
@@ -191,18 +190,6 @@ async def handle_messages(messages: Any, callback: Callable[[str, str], None]) -
         payload = message.payload.decode()
         LOGGER.debug("Received message topic: %s, payload: %s", message.topic, payload)
         callback(message.topic, payload)
-
-
-async def cancel_tasks(tasks: Set[asyncio.Task]) -> None:
-    """Cancel tasks."""
-    for task in tasks:
-        if task.done():
-            continue
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
 
 
 async def run_client() -> None:

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -130,6 +130,7 @@ class MQTTClient:
         while True:
             to_publish: tuple = await self.publish_queue.get()
             await self.publish(*to_publish)
+            self.publish_queue.task_done()
 
     async def start_client(self, manager: OZWManager) -> None:
         """Start the client with the manager."""

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -180,7 +180,6 @@ class MQTTClient:
             await self.subscribe(topic)
 
             # Wait for everything to complete (or fail due to, e.g., network errors).
-            # Make sure we await new tasks added while awaiting the first tasks.
             await asyncio.gather(*tasks)
 
     async def unsubscribe_manager(self, manager: OZWManager) -> None:

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -21,8 +21,6 @@ TOPIC_OPENZWAVE = "OpenZWave"
 class MQTTClient:
     """Represent an MQTT client."""
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(
         self,
         host: str,

--- a/openzwavemqtt/util/mqtt_client.py
+++ b/openzwavemqtt/util/mqtt_client.py
@@ -40,7 +40,6 @@ class MQTTClient:
         self.asyncio_client: AsyncioClient = None
         self.create_client()
         self.reconnect_interval = 1
-        self.client_task: Optional[asyncio.Task] = None
         self.publish_queue: asyncio.Queue = asyncio.Queue()
 
     def create_client(self) -> None:
@@ -134,7 +133,6 @@ class MQTTClient:
 
     async def start_client(self, manager: OZWManager) -> None:
         """Start the client with the manager."""
-        self.client_task = asyncio.current_task()
         # Reconnect automatically until the client is stopped.
         while True:
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+asyncio-mqtt==0.8.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 -r requirements_lint.txt
 -r requirements_script.txt
 -r requirements_test.txt

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     python_requires=">=3.7",
     include_package_data=True,
     zip_safe=False,
+    install_requires=["asyncio-mqtt"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
     python_requires=">=3.7",
     include_package_data=True,
     zip_safe=False,
-    install_requires=["asyncio-mqtt"],
+    extras_require={
+        "mqtt-client": ["asyncio-mqtt"],
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands =
   pylint openzwavemqtt script test
   pydocstyle openzwavemqtt script test
 deps =
+  -rrequirements.txt
   -rrequirements_lint.txt
   -rrequirements_script.txt
   -rrequirements_test.txt
@@ -32,5 +33,6 @@ ignore_errors = True
 commands =
   mypy openzwavemqtt script
 deps =
+  -rrequirements.txt
   -rrequirements_lint.txt
   -rrequirements_script.txt


### PR DESCRIPTION
- Add a MQTT client util.
- Use asyncio-mqtt library to handle mqtt client details: https://pypi.org/project/asyncio-mqtt/
- The interface to start the client looks like this:
```py
async def run_client() -> None:
    """Run client."""
    client = MQTTClient("localhost")
    options = OZWOptions(
        send_message=client.send_message, topic_prefix=f"{TOPIC_OPENZWAVE}/"
    )
    manager = OZWManager(options)

    await client.start_client(manager)


def main() -> None:
    """Run main."""
    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
    logging.basicConfig(format=fmt, level=logging.DEBUG)
    LOGGER.info("Starting client.")

    try:
        asyncio.run(run_client())
    except KeyboardInterrupt:
        LOGGER.info("Exiting client.")
```
- A clean client session will be used so the broker will forget topics etc when the client disconnects.